### PR TITLE
Create an ble to nb-iot bridge

### DIFF
--- a/nbiot-cpp-template/config.json
+++ b/nbiot-cpp-template/config.json
@@ -1,7 +1,17 @@
 {
     "microbit-dal":{
-        "bluetooth": {
-            "enabled": 0
+        "bluetooth":{
+            "enabled": 1,
+            "pairing_mode": 0,
+            "private_addressing": 0,
+            "open": 0,
+            "whitelist": 0,
+            "advertising_timeout": 0,
+            "tx_power": 7,
+            "dfu_service": 0,
+            "event_service": 0,
+            "device_info_service": 0,
+            "eddystone_url": 0
         },
         "debug": 1
     }

--- a/nbiot-cpp-template/simulate_nbiot.py
+++ b/nbiot-cpp-template/simulate_nbiot.py
@@ -1,0 +1,62 @@
+import serial
+import sys
+import time
+import socket
+import binascii
+
+data_to_udp = None
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+sock.bind(('0.0.0.0', 7899))
+sock.setblocking(False)
+            
+ser = serial.serial_for_url('/dev/ttyUSB0', baudrate=9600, timeout = 0.1)
+
+def ser_write(msg):
+    print('UART TX: ' + str(msg))
+    ser.write(msg)
+    ser.flush()
+    time.sleep(0.2)
+            
+while True:
+    
+    
+    currentLine = ser.readline().decode('utf-8','ignore')
+
+    if "AT+" in currentLine:
+        print('UART RX: ' + str(currentLine).strip() + '\r\n')
+        if "AT+CGATT?" in currentLine:
+            msg = '+CGATT:1\r\n'.encode()
+            ser_write(msg)
+            
+        if "AT+NSOST" in currentLine:
+            nsost = currentLine.split(',')
+            udp_msg_addr = nsost[1]
+            udp_msg_port = nsost[2]
+            udp_msg_len = nsost[3]
+            udp_msg_payload = nsost[4].strip()
+            print(udp_msg_payload)
+            udp_msg_payload = bytearray.fromhex(udp_msg_payload)
+            print(udp_msg_payload)
+            sock.sendto(udp_msg_payload, (udp_msg_addr, int(udp_msg_port)))
+        if "AT+NSORF" in currentLine:
+            if data_to_udp:
+                hex_udp_frame = str(binascii.hexlify(data_to_udp),'ascii')
+                msg = ('+NSONMI:0,' + str(len(data_to_udp)) + '\r\n').encode()
+                ser_write(msg)
+                msg = ('0,198.199.120.16,2115,' + str(len(data_to_udp)) + ',' + hex_udp_frame + ',0\r\n').encode()
+                ser_write(msg)
+                data_to_udp = None
+
+        msg = 'OK\r\n'.encode()
+        ser_write(msg)
+    udp_recv_data = None
+    try:
+        udp_recv_data = sock.recv(128)
+    except:
+        pass
+    
+    if udp_recv_data:
+        data_to_udp = udp_recv_data
+        
+    

--- a/nbiot-cpp-template/source/utils/utils.cpp
+++ b/nbiot-cpp-template/source/utils/utils.cpp
@@ -108,6 +108,16 @@ ManagedString stringToHex(ManagedString &input) {
     return r;
 }
 
+ManagedString stringToHex(const char* input, uint16_t len) {
+    const char l[17] = "0123456789ABCDEF";
+    ManagedString r;
+    for (int i = 0; i < len; i++) {
+        char c = input[i];
+        r = r + ManagedString(l[c >> 4]) + ManagedString(l[c & 0x0f]);
+    }
+    return r;
+}
+
 void hexdump(const char *prefix, const uint8_t *b, size_t size) {
     for (unsigned int i = 0; i < size; i += 16) {
         if (prefix && strlen(prefix) > 0) printf("%s %06x: ", prefix, i);
@@ -126,4 +136,42 @@ void hexdump(const char *prefix, const uint8_t *b, size_t size) {
 void hexprint(const uint8_t *b, size_t size) {
     for (unsigned int i = 0; i < size; i++) printf("%02x", b[i]);
     printf("\r\n");
+}
+
+
+static uint8_t hexToUint8(char ch) {
+    // service digits 0 - 9
+    if ( ( ch >= '0' ) && ( ch <= '9' ) ) {
+        return ch - '0';
+    }
+    // and then lowercase a - f
+    else if ( ( ch >= 'a' ) && ( ch <= 'f' ) ) 
+    {
+        return ch - 'a' + 10;
+    }
+    // and uppercase A - F
+    else if ( ( ch >= 'A' ) && ( ch <= 'F' ) ) 
+    {
+        return ch - 'A' + 10;
+    }
+    return 0xFF; // error
+}
+
+// like no input sanitation..., output needs to be at least 20bytes
+uint8_t hexarrayToByte(uint8_t* output, ManagedString input) {
+    int charPos = 0;
+    int bytePos = 0;
+    while (charPos < input.length()) {
+        uint8_t firstNibble = hexToUint8(input.charAt(charPos));
+        charPos++;
+        uint8_t secondNibble = hexToUint8(input.charAt(charPos));
+        charPos++;
+        if ((firstNibble != 0xFF) && (secondNibble != 0xFF)) {
+            output[bytePos] = firstNibble << 4 | secondNibble;
+        } else {
+            return 0;
+        }
+        bytePos++;
+    }
+    return bytePos;
 }

--- a/nbiot-cpp-template/source/utils/utils.h
+++ b/nbiot-cpp-template/source/utils/utils.h
@@ -43,6 +43,14 @@ ManagedString sign(ManagedString &message, const unsigned char *signKey = nullpt
 ManagedString stringToHex(ManagedString &input);
 
 /**
+ * Convert the input into a hex encoded string.
+ * @param input the input
+ * @param len the length of input
+ * @return the hex encoded string
+ */
+ManagedString stringToHex(const char* input, uint16_t len);
+
+/**
  * Dump an array in hex-dump style with a prefix.
  * @param prefix the prefix prepended to each line
  * @param b the byte array to dump
@@ -56,5 +64,16 @@ void hexdump(const char *prefix, const uint8_t *b, size_t size);
  * @param size the size of the byte array
  */
 void hexprint(const uint8_t  *b, size_t size);
+
+/**
+ * Convert the hexchar array input to a byte array
+ * Little to no input sanitation
+ * 
+ * @param output pointer to the target buffer
+ * @param input the string to convert
+ * @return the length of the resulting byte array in output
+ */
+uint8_t hexarrayToByte(uint8_t* output, ManagedString input);
+
 
 #endif //NBIOT_CPP_TEMPLATE_UTILS_H


### PR DESCRIPTION
* Add receiving udp packets
* create a ble uart interface
* route packets from ble to nd-iot and vice versa

Hallo!
Hier wie versprochen das Ergebnis unserer 'downstream' Erweiterung fuer das nb-iot Beispiel auf dem DTHack17 Hackathon.
Hat mega Laune gemacht und da hab ich euch viel fuer zu verdanken, also Danke sehr und ich hoffe hiermit etwas zurueckgeben zu koennen.


Es macht sich einige haarige Netzwerksachen zu Nutze, unter anderem wohl uebles NAT, da alles noch ueber IPv4 laeuft.
Der Socket port auf dem NB-IOT Modul wird ignoriert. Auf Server Seite muss man auf das 'Oi!' hin das Socket offen halten und alle an das Modul addressierten Nachrichten an das gleiche IP/Port Tupel schicken von dem das 'Oi' kam. Das ist nicht sonderlich zustandslos wie es eigentlich fuer UDP vorgesehen ist, funktioniert aber. Sauber waere natuerlich ordentliches routing und IPv6.
Das +NSONMI handling im Nachrichtenempfang ist nicht sehr sauber, funktionierte aber ganz passabel. Ich glaube die Meldung kann auf jeden AT+ Befehl hin als Ergebniszeile kommen, zurzeit wird sie nur als Antwort auf 'AT+NSORF=0,20' erwartet

Zusaetzlich gibts als Dreingabe noch die Bruecke zu eine BLE UART Interface, so das es quasi nur eine Weiterleitung zwischen der BLE Seite und der NB-IOT Seite ist.
Durch die BLE Methoden sind viele Daten byte arrays und nicht mehr einfach nullterminiert, weswegen zum ManagedString handling noch ein (char* buffer, int len) handling und byteZuHex array in den utils dazu kam.

Da wir in Frankfurt leider noch kein NB-IOT haben (Stand 25.9.2017) hab ich ein 'NB-IOT Simulator' in Python geschrieben, der quasi die Rolle des NB-IOT Modul mit einem Rechner und USB2Serial Adapter uebernehmen kann.

GPS per I2C hab ich erstmal wieder rausgeschmissen, funktionierte zwar aber ich habe kein Modul mehr zum testen, da ich es zurueckgegeben habe. Ohne GPS macht das ganze auch einen runderen Eindruck.


Schoene Gruesse,
Karsten von COBI :-)

Folgende Aenderungen sind an den per yotta eingebunden Modulen noetig/sinnvoll, keine Ahnung wie ich die sinnvoll beitragen kann, deswegen einfach copy und paste vom diff

--- ./yotta_modules/microbit-dal/inc/drivers/MicroBitSerial.h	2017-09-25 13:44:11.052015815 +0200
+++ ../../telekom-nbiot-hackathon-2017-bak/nbiot-cpp-template/yotta_modules/microbit-dal/inc/drivers/MicroBitSerial.h	2017-09-25 13:21:34.140072820 +0200
@@ -30,7 +30,7 @@
 #include "ManagedString.h"
 
 #define MICROBIT_SERIAL_DEFAULT_BAUD_RATE   115200
-#define MICROBIT_SERIAL_DEFAULT_BUFFER_SIZE 20
+#define MICROBIT_SERIAL_DEFAULT_BUFFER_SIZE 127
 
 #define MICROBIT_SERIAL_EVT_DELIM_MATCH     1
 #define MICROBIT_SERIAL_EVT_HEAD_MATCH      2

--- ./yotta_modules/microbit-dal/source/bluetooth/MicroBitBLEManager.cpp	2017-08-01 21:28:46.000000000 +0200
+++ ../../telekom-nbiot-hackathon-2017-bak/nbiot-cpp-template/yotta_modules/microbit-dal/source/bluetooth/MicroBitBLEManager.cpp	2017-09-25
@@ -304,14 +307,14 @@
 //#ifdef TARGET_NRF51_CALLIOPE
 //    ManagedString BLEName("Calliope mini");
 //#else
-    ManagedString BLEName("BBC micro:bit");
+    ManagedString BLEName("DATA SLING");
 //#endif
     this->deviceName = deviceName;
 
 #if !(CONFIG_ENABLED(MICROBIT_BLE_WHITELIST))
     ManagedString namePrefix(" [");
     ManagedString namePostfix("]");
-    BLEName = BLEName + namePrefix + deviceName + namePostfix;
+    BLEName = BLEName;
 #endif
 
 // Start the BLE stack.
